### PR TITLE
Ignore unfitted indices in FitScore calculation

### DIFF
--- a/Dynamic/Identification/FitScoreCalculator.cs
+++ b/Dynamic/Identification/FitScoreCalculator.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,16 +20,17 @@ namespace TimeSeriesAnalysis
         /// </summary>
         /// <param name="meas"></param>
         /// <param name="sim"></param>
+        /// <param name="indToIgnore"></param>
         /// <returns> a fit score that is maximum 100 percent, but can also go negative if fit is poor</returns>
-        public static double Calc(double[] meas, double[] sim)
+        public static double Calc(double[] meas, double[] sim,  List<int> indToIgnore = null)
         {
             if (meas == null)
                 return double.NaN;
             if (sim == null)
                 return double.NaN;
 
-            double dev = Deviation(meas, sim);
-            double devFromSelf = DeviationFromAvg(meas);
+            double dev = Deviation(meas, sim, indToIgnore);
+            double devFromSelf = DeviationFromAvg(meas, indToIgnore);
 
             double fitScore = 0;
             if ( !Double.IsNaN(dev))
@@ -181,8 +182,9 @@ namespace TimeSeriesAnalysis
         /// </summary>
         /// <param name="reference"></param>
         /// <param name="model"></param>
+        /// <param name="indToIgnore"></param>
         /// <returns></returns>
-        private static double Deviation(double[] reference, double[] model)
+        private static double Deviation(double[] reference, double[] model, List<int> indToIgnore = null)
         {
             if (reference == null)
                 return double.NaN;
@@ -196,6 +198,11 @@ namespace TimeSeriesAnalysis
             double N = 0;
             for (var i = 0; i < Math.Min(reference.Length, model.Length); i++)
             {
+                if (indToIgnore != null)
+                {
+                    if (indToIgnore.Contains(i))
+                        continue;
+                }
                 ret += Math.Abs(reference[i] - model[i]);
                 N++;
             }
@@ -205,7 +212,7 @@ namespace TimeSeriesAnalysis
             return ret;
         }
 
-        private static double DeviationFromAvg(double[] signal)
+        private static double DeviationFromAvg(double[] signal, List<int> indToIgnore = null)
         {
             if (signal == null) return double.NaN;
             if (signal.Length == 0) return double.NaN;
@@ -216,11 +223,17 @@ namespace TimeSeriesAnalysis
             if (!avg.HasValue)
                 return double.NaN;
 
-            var N = signal.Length;
+            var N = 0;
             double ret = 0;
-            for (var i = 0; i < N; i++)
+            for (var i = 0; i < signal.Length; i++)
             {
+                if (indToIgnore != null)
+                {
+                    if (indToIgnore.Contains(i))
+                        continue;
+                }
                 ret += Math.Abs(signal[i] - avg.Value);
+                N++;
             }
             return ret / N;
         }

--- a/Dynamic/Identification/PidIdentifier.cs
+++ b/Dynamic/Identification/PidIdentifier.cs
@@ -378,8 +378,6 @@ namespace TimeSeriesAnalysis.Dynamic
 
                 double[] ucur, uprev, ecur, eprev;
 
-                List<int> indicesToIgnore = new List<int>();
-
                 double[] e_scaled;
                 double yScaleFactor = 1;
                 if (pidParam.Scaling.IsKpScalingOn())
@@ -512,23 +510,6 @@ namespace TimeSeriesAnalysis.Dynamic
             }
 
             indicesToIgnoreForEvalSim = indicesToIgnoreForEvalSim.Union(indBadU).ToList();
-
-            if (ignoreFlatLines)
-            {
-                // Identify oversampled data
-                List<int> indSameU = new List<int>();
-                for (int i = 0; i < dataSet.U.GetNColumns(); i++)
-                {
-                   indSameU = indSameU.Union(vec.FindValues(dataSet.U.GetColumn(i), -9999, VectorFindValueType.SameAsPrevious)).ToList();
-                }
-                List<int> indSameYmeas = vec.FindValues(dataSet.Y_meas, -9999, VectorFindValueType.SameAsPrevious);
-                List<int> indSameYsetpoint = vec.FindValues(dataSet.Y_setpoint, -9999, VectorFindValueType.SameAsPrevious);
-                List<int> indOversampled = indSameU.Intersect(indSameYmeas).ToList();
-                indOversampled = indOversampled.Intersect(indSameYsetpoint).ToList();
-
-                indicesToIgnoreForEvalSim = indicesToIgnoreForEvalSim.Union(indOversampled).ToList();
-                indicesToIgnoreForEvalSim.Sort();
-            }
 
             // see if using "next value= last value" gives better objective function than the model found"
             // if so it is an indication that something is wrong

--- a/TimeSeriesAnalysis/Vec.cs
+++ b/TimeSeriesAnalysis/Vec.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -1202,9 +1202,9 @@ namespace TimeSeriesAnalysis
             // Plot.FromList(new List<double[]> { x_mod_int , x_meas_int },new List<string> {"y1=xmod","y1=xmeas" },
             //      TimeSeriesCreator.CreateDateStampArray(new DateTime(2000,1,1),1, x_mod_int.Length));
             //  double SSres = SumOfSquareErr(x_mod_int, x_meas_int, 0, false);
-            double SSres = SumOfSquareErr(x_mod_int, x_meas_int, ymodOffset, false);//explainedVariation
-            double meanOfMeas = Mean(x_meas_int).Value;
-            double SStot = SumOfSquareErr(x_mod_int, meanOfMeas, false); //totalVariation
+            double SSres = SumOfSquareErr(x_mod_int, x_meas_int, ymodOffset, false, indToIgnore);//explainedVariation
+            double meanOfMeas = Mean(x_meas_int, indToIgnore).Value;
+            double SStot = SumOfSquareErr(x_mod_int, meanOfMeas, false, indToIgnore); //totalVariation
             double Rsq = 1 - SSres / SStot;
             return Rsq;
         }
@@ -1382,15 +1382,22 @@ namespace TimeSeriesAnalysis
         /// Sum of the square errors of the vector compared to a constant. by default the return value is normalized by dividing by the number of elements;
         /// this normalization can be turned off.
         /// </summary>
-        public static double SumOfSquareErr(double[] vec, double constant, bool doNormalization = true)
+        public static double SumOfSquareErr(double[] vec, double constant, bool doNormalization = true, List<int> indToIgnore=null)
         {
             double ret = 0;
+            int nGoodValues = 0;
             for (int i = 0; i < vec.Count(); i++)
             {
+                if (indToIgnore != null)
+                {
+                    if (indToIgnore.Contains(i))
+                        continue;
+                }
+                nGoodValues++;
                 ret += Math.Pow(vec[i] - constant, 2);
             }
             if (doNormalization)
-                return ret / vec.Length;
+                return ret / nGoodValues;
             else
                 return ret;
         }


### PR DESCRIPTION
During fitting various checks ensure that the indices of bad data points are excluded from the fitting algorithm. This pull request adds a corresponding list of indices to the R-Squared and FitScore calculations. This ensures that the comparison of various fits is handled fairly, with the model that scores **best** on the data _it was tuned on_ being returned.

In addition the FitScore comparison for the different PidIdentifier-tunings has been altered with the improved FitScore / R-Squared values in mind.