### PR TITLE
Feature/add downsampling starting point

### DIFF
--- a/Dynamic/UnitSimulator/UnitDataSet.cs
+++ b/Dynamic/UnitSimulator/UnitDataSet.cs
@@ -1,4 +1,4 @@
-﻿using Accord.IO;
+using Accord.IO;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
@@ -141,16 +141,17 @@ namespace TimeSeriesAnalysis.Dynamic
         /// </summary>
         /// <param name="originalDataSet"></param>
         /// <param name="downsampleFactor">factor by which to downsample the original dataset</param>
-        public UnitDataSet(UnitDataSet originalDataSet, int downsampleFactor)
+        /// <param name="keyIndex">index around which to center the downsampling</param>
+        public UnitDataSet(UnitDataSet originalDataSet, double downsampleFactor, int keyIndex=0)
         {
             this.ProcessName = originalDataSet.ProcessName + "downsampledFactor" + downsampleFactor;
 
-            this.Y_meas = Vec<double>.Downsample(originalDataSet.Y_meas, downsampleFactor);
-            this.Y_setpoint = Vec<double>.Downsample(originalDataSet.Y_setpoint, downsampleFactor);
-            this.Y_sim = Vec<double>.Downsample(originalDataSet.Y_sim, downsampleFactor);
-            this.U = Array2D<double>.Downsample(originalDataSet.U, downsampleFactor);
-            this.U_sim = Array2D<double>.Downsample(originalDataSet.U_sim, downsampleFactor);
-            this.Times = Vec<DateTime>.Downsample(originalDataSet.Times, downsampleFactor);
+            this.Y_meas = Vec<double>.Downsample(originalDataSet.Y_meas, downsampleFactor, keyIndex);
+            this.Y_setpoint = Vec<double>.Downsample(originalDataSet.Y_setpoint, downsampleFactor, keyIndex);
+            this.Y_sim = Vec<double>.Downsample(originalDataSet.Y_sim, downsampleFactor, keyIndex);
+            this.U = Array2D<double>.Downsample(originalDataSet.U, downsampleFactor, keyIndex);
+            this.U_sim = Array2D<double>.Downsample(originalDataSet.U_sim, downsampleFactor, keyIndex);
+            this.Times = Vec<DateTime>.Downsample(originalDataSet.Times, downsampleFactor, keyIndex);
         }
 
         /// <summary>

--- a/TimeSeriesAnalysis/Array2DGeneric.cs
+++ b/TimeSeriesAnalysis/Array2DGeneric.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -189,8 +189,9 @@ namespace TimeSeriesAnalysis
         /// </summary>
         /// <param name="matrix"></param>
         /// <param name="downsampleFactor"></param>
+        /// <param name="keyindex"></param>
         /// <returns></returns>
-        static public T[,] Downsample(T[,] matrix, int downsampleFactor)
+        static public T[,] Downsample(T[,] matrix, double downsampleFactor, int keyindex = 0)
         {
             if (matrix == null)
                 return null;
@@ -202,7 +203,7 @@ namespace TimeSeriesAnalysis
             {
                 T[] curCol = Array2D<T>.GetColumn(matrix, colIdx);
 
-                ret[colIdx] = Vec<T>.Downsample(curCol, downsampleFactor);
+                ret[colIdx] = Vec<T>.Downsample(curCol, downsampleFactor, keyindex);
             }
             var jaggedRet = Created2DFromJagged(ret);
             return Array2D<T>.Transpose(jaggedRet);

--- a/TimeSeriesAnalysis/TimeSeriesDataSet.cs
+++ b/TimeSeriesAnalysis/TimeSeriesDataSet.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -317,20 +317,39 @@ namespace TimeSeriesAnalysis
 
 
         /// <summary>
-        /// Returns a copy of the dataset that is downsampled by the given factor
+        /// Returns a copy of the dataset that is downsampled by the given factor.
         /// </summary>
-        /// <param name="downsampleFactor">value greater than 1 indicating that every nth value of the orignal data will be transferred</param>
+        /// <param name="downsampleFactor">value greater than 1 indicating that every Floor(n*factor) value of the orignal data will be transferred.</param>
+        /// <param name="keyIndex">optional index around which to perform the downsampling.</param>
         /// <returns></returns>
-        public TimeSeriesDataSet CreateDownsampledCopy(int downsampleFactor)
+        public TimeSeriesDataSet CreateDownsampledCopy(double downsampleFactor, int keyIndex = 0)
         {
             TimeSeriesDataSet ret = new TimeSeriesDataSet();
 
-            ret.timeStamps = Vec<DateTime>.Downsample(timeStamps.ToArray(), downsampleFactor).ToList();
-            //ret.N = ret.timeStamps.Count();
+            ret.timeStamps = Vec<DateTime>.Downsample(timeStamps.ToArray(), downsampleFactor, keyIndex).ToList();
             ret.dataset_constants = dataset_constants;
             foreach (var item in dataset)
             {
-                ret.dataset[item.Key] = Vec<double>.Downsample(item.Value, downsampleFactor);
+                ret.dataset[item.Key] = Vec<double>.Downsample(item.Value, downsampleFactor, keyIndex);
+            }
+            return ret;
+        }
+
+        /// <summary>
+        /// Returns a copy of the dataset that is oversampled by the given factor.
+        /// </summary>
+        /// <param name="oversampleFactor">value greater than 1 indicating that every value will be sampled until (i / factor > 1).</param>
+        /// <param name="keyIndex">optional index around which to perform the oversampling.</param>
+        /// <returns></returns>
+        public TimeSeriesDataSet CreateOversampledCopy(double oversampleFactor, int keyIndex = 0)
+        {
+            TimeSeriesDataSet ret = new TimeSeriesDataSet();
+
+            ret.CreateTimestamps(timeBase_s: GetTimeBase() / oversampleFactor, N: (int)Math.Ceiling(GetNumDataPoints() * oversampleFactor), t0: timeStamps[0]);
+            ret.dataset_constants = dataset_constants;
+            foreach (var item in dataset)
+            {
+                ret.dataset[item.Key] = Vec<double>.Oversample(item.Value, oversampleFactor, keyIndex);
             }
             return ret;
         }

--- a/TimeSeriesAnalysis/TimeSeriesDataSet.cs
+++ b/TimeSeriesAnalysis/TimeSeriesDataSet.cs
@@ -336,25 +336,6 @@ namespace TimeSeriesAnalysis
         }
 
         /// <summary>
-        /// Returns a copy of the dataset that is oversampled by the given factor.
-        /// </summary>
-        /// <param name="oversampleFactor">value greater than 1 indicating that every value will be sampled until (i / factor > 1).</param>
-        /// <param name="keyIndex">optional index around which to perform the oversampling.</param>
-        /// <returns></returns>
-        public TimeSeriesDataSet CreateOversampledCopy(double oversampleFactor, int keyIndex = 0)
-        {
-            TimeSeriesDataSet ret = new TimeSeriesDataSet();
-
-            ret.CreateTimestamps(timeBase_s: GetTimeBase() / oversampleFactor, N: (int)Math.Ceiling(GetNumDataPoints() * oversampleFactor), t0: timeStamps[0]);
-            ret.dataset_constants = dataset_constants;
-            foreach (var item in dataset)
-            {
-                ret.dataset[item.Key] = Vec<double>.Oversample(item.Value, oversampleFactor, keyIndex);
-            }
-            return ret;
-        }
-
-        /// <summary>
         /// Creates internal timestamps from a given start time and timebase, must be called after filling the values 
         /// </summary>
         /// <param name="timeBase_s">the time between samples in the dataset, in total seconds</param>

--- a/TimeSeriesAnalysis/VecGeneric.cs
+++ b/TimeSeriesAnalysis/VecGeneric.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace TimeSeriesAnalysis
@@ -46,21 +47,41 @@ namespace TimeSeriesAnalysis
 
 
         /// <summary>
-        /// Downsample a vector by a given factor(selet only every Nth value)
+        /// Downsample a vector by a given factor by choosing every Floor(factor*n) value.
+        /// The optional key index indicates an index for which to base the downsampling around.
         /// </summary>
         /// <param name="vec"></param>
         /// <param name="factor"></param>
+        /// <param name="keyIndex"></param>
         /// <returns></returns>
-        static public T[] Downsample(T[] vec, int factor)
+        static public T[] Downsample(T[] vec, double factor, int keyIndex = 0)
         {
             if (vec == null)
                 return null;
             if (factor <= 1)
                 return vec;
-            var ret = new List<T>();
-            for (int i = 0; i < vec.Length; i += factor)
+            
+            // Find downsampled indices
+            var ind = new List<int>();
+            int count = 0;
+            for (int i = keyIndex; i >= 0; i = keyIndex - (int)Math.Ceiling(factor*count))
             {
-                ret.Add(vec[i]);
+                ind.Add(i);
+                count++;
+            }
+            count = 1;
+            for (int i = keyIndex + (int)Math.Floor(factor); i < vec.Length; i = keyIndex + (int)Math.Floor(factor*count))
+            {
+                ind.Add(i);
+                count++;
+            }
+            ind.Sort();
+
+            // Populate and return downsampled vector
+            var ret = new List<T>();
+            for (int i = 0; i < ind.Count(); i++)
+            {
+                ret.Add(vec[ind[i]]);
             }
             return ret.ToArray();
         }


### PR DESCRIPTION
For non-integer downsampling factors the starting index for downsampling becomes important. This pull request adds the support for an optional parameter KeyIndex in the downsampling functions, as well as a default method for identifying said index.