### PR TITLE
Use average timebase and allow non-integer timebases

### DIFF
--- a/TimeSeriesAnalysis/TimeSeriesDataSet.cs
+++ b/TimeSeriesAnalysis/TimeSeriesDataSet.cs
@@ -339,6 +339,7 @@ namespace TimeSeriesAnalysis
         /// Creates internal timestamps from a given start time and timebase, must be called after filling the values 
         /// </summary>
         /// <param name="timeBase_s">the time between samples in the dataset, in total seconds</param>
+        /// <param name="N">number of datapoints</param>
         /// <param name="t0">start time, can be null, which can be usedful for testing</param>
         public void CreateTimestamps(double timeBase_s, int N=0, DateTime? t0 = null)
         {
@@ -417,18 +418,19 @@ namespace TimeSeriesAnalysis
         {
             if (timeStamps == null)
                 return 0;
-            return timeStamps.Count - 1;
+            return timeStamps.Count;
         }
 
         /// <summary>
-        /// Get the timebase, the time between two samples in the dataset
+        /// Get the timebase, the average time between two samples in the dataset
         /// </summary>
         /// <returns>The timebase in seconds</returns>
         public double GetTimeBase()
         {
             if (timeStamps.Count > 2)
             {
-                return timeStamps[2].Subtract(timeStamps[1]).TotalSeconds;
+                int N = GetNumDataPoints();
+                return timeStamps[N-1].Subtract(timeStamps[0]).TotalSeconds / (N-1);
             }
             else
                 return 0;

--- a/Utility/TimeSeriesCreator.cs
+++ b/Utility/TimeSeriesCreator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -44,10 +44,10 @@ namespace TimeSeriesAnalysis.Utility
         /// Create an array of DateTimes starting at <c>t0</c> of length N and with sampling interval <c>dT_s</c>
         /// </summary>
         /// <param name="t0">first datetime in the array to be created</param>
-        /// <param name="dT_s">sampling internval</param>
+        /// <param name="dT_s">sampling interval</param>
         /// <param name="N">number of desired data points</param>
         /// <returns></returns>
-        static public DateTime[] CreateDateStampArray(DateTime t0, int dT_s, int N)
+        static public DateTime[] CreateDateStampArray(DateTime t0, double dT_s, int N)
         {
             List<DateTime> times = new List<DateTime>();
             DateTime curTime = t0;
@@ -62,12 +62,12 @@ namespace TimeSeriesAnalysis.Utility
         /// <summary>
         /// Create an array representing a sinus
         /// </summary>
-        /// <param name="amplitude">amplitud of sinus</param>
+        /// <param name="amplitude">amplitude of sinus</param>
         /// <param name="sinusPeriod_s">time for a complete 360 degree period of the sinus in seconds</param>
         /// <param name="dT_s">the timebase</param>
-        /// <param name="N">number of desired data point in return array</param>
-        /// <returns>an array continaing the specified sinus</returns>
-        static public double[] Sinus(double amplitude, double sinusPeriod_s, int dT_s, int N)
+        /// <param name="N">number of desired data points in return array</param>
+        /// <returns>an array containing the specified sinus</returns>
+        static public double[] Sinus(double amplitude, double sinusPeriod_s, double dT_s, int N)
         {
             List<double> list = new List<double>();
 


### PR DESCRIPTION
In case there are temporally unevenly spread data points, the timebase will with this pull request be calculated as the average time between two data points, instead of assuming the time between the first two data points is representative. This will improve the integer time identification for the cases with somewhat unevenly spread data points, and it will improve results from 
downsampling using non-integer downsample factors.

Additionally, non-integer timebases are allowed in the timeseries creator.