### PR TITLE
Feature/add oversampled dataset handling

### DIFF
--- a/Dynamic/Identification/PidIdentifier.cs
+++ b/Dynamic/Identification/PidIdentifier.cs
@@ -78,7 +78,17 @@ namespace TimeSeriesAnalysis.Dynamic
             const bool DoFiltering = true; // default is true (this improves performance significantly)
             const bool returnFilterParameters = false; // even if filtering helps improve estimates, maybe the filter should not be returned?
 
+            // Find the oversampled factor if relevant
             bool ignoreFlatLinesFirst = ignoreFlatLines;
+            if (downsampleOversampledData & ignoreFlatLinesFirst)
+            {
+                double oversampledFactor = dataSet.GetOversampledFactor(out int keyIndex);
+                // Oversamples of less than 20 percent can be handled by the flatline index ignoration.
+                if (oversampledFactor > 1.2)
+                {
+                    ignoreFlatLinesFirst = false;
+                }
+            }
 
             // 1. try identification with delay of one sample but without filtering
             (PidParameters results_withDelay, double[,] U_withDelay) = IdentifyInternal(dataSet, true, ignoreFlatLines: ignoreFlatLinesFirst);

--- a/Dynamic/Identification/PidIdentifier.cs
+++ b/Dynamic/Identification/PidIdentifier.cs
@@ -72,7 +72,7 @@ namespace TimeSeriesAnalysis.Dynamic
         /// <param name="downsampleOversampledData">Boolean, whether to do internal oversample identification and attempt downsampling. Defaults to true.</param>
         /// <param name="ignoreFlatLines">Boolean, whether to do internal flatline identification and ignore their indices. Defaults to true.</param>
         /// <returns>the identified parameters of the PID-controller</returns>
-        public PidParameters Identify(ref UnitDataSet dataSet, bool downsampleOversampledData = true)
+        public PidParameters Identify(ref UnitDataSet dataSet, bool downsampleOversampledData = true, bool ignoreFlatLines = true)
         {
             const bool doOnlyWithDelay = false;// should be false unless debugging something
             const bool DoFiltering = true; // default is true (this improves performance significantly)

--- a/Dynamic/Identification/PidIdentifier.cs
+++ b/Dynamic/Identification/PidIdentifier.cs
@@ -89,7 +89,7 @@ namespace TimeSeriesAnalysis.Dynamic
 
             // 2. try identification without delay of one sample (yields better results often if dataset is downsampled
             //    relative to the clock that the pid algorithm ran on originally)
-            (PidParameters results_withoutDelay, double[,] U_withoutDelay) = IdentifyInternal(dataSet, false);
+            (PidParameters results_withoutDelay, double[,] U_withoutDelay) = IdentifyInternal(dataSet, false, ignoreFlatLines: ignoreFlatLinesFirst);
 
             // save which is the "best" estimate for comparison 
             bool doDelay = true;
@@ -117,7 +117,7 @@ namespace TimeSeriesAnalysis.Dynamic
                 for (double filterTime_s = timeBase_s; filterTime_s < maxFilterTime_s; filterTime_s += timeBase_s)
                 {
                     var pidFilterParams = new PidFilterParams(true, 1, filterTime_s);
-                    (PidParameters results_withFilter, double[,] U_withFilter) = IdentifyInternal(dataSet, doDelay, pidFilterParams);
+                    (PidParameters results_withFilter, double[,] U_withFilter) = IdentifyInternal(dataSet, doDelay, pidFilterParams, ignoreFlatLines: ignoreFlatLinesFirst);
 
                     if (IsFirstModelBetterThanSecondModel(results_withFilter, bestPidParameters))
                     {
@@ -135,7 +135,7 @@ namespace TimeSeriesAnalysis.Dynamic
                 {
                     var pidFilterParams = new PidFilterParams(true, 1, filterTime_s);
                     (PidParameters results_withFilter, double[,] U_withFilter) =
-                        IdentifyInternal(dataSet, doDelay, pidFilterParams, filterUmeas);
+                        IdentifyInternal(dataSet, doDelay, pidFilterParams, filterUmeas, ignoreFlatLines: ignoreFlatLinesFirst);
 
                     if (IsFirstModelBetterThanSecondModel(results_withFilter, bestPidParameters))
                     {
@@ -156,7 +156,7 @@ namespace TimeSeriesAnalysis.Dynamic
                     if (dataSet.Times.Count() != dataSetDownsampled.Times.Count())
                     {
                         pidFilter = null;
-                        PidParameters results_downsampled = Identify(ref dataSetDownsampled);
+                        PidParameters results_downsampled = Identify(ref dataSetDownsampled, ignoreFlatLines: ignoreFlatLines);
                         if (IsFirstModelBetterThanSecondModel(results_downsampled, bestPidParameters))
                         {
                             bestU = dataSetDownsampled.U_sim;

--- a/Dynamic/Identification/PidIdentifier.cs
+++ b/Dynamic/Identification/PidIdentifier.cs
@@ -78,8 +78,10 @@ namespace TimeSeriesAnalysis.Dynamic
             const bool DoFiltering = true; // default is true (this improves performance significantly)
             const bool returnFilterParameters = false; // even if filtering helps improve estimates, maybe the filter should not be returned?
 
+            bool ignoreFlatLinesFirst = ignoreFlatLines;
+
             // 1. try identification with delay of one sample but without filtering
-            (PidParameters results_withDelay, double[,] U_withDelay) = IdentifyInternal(dataSet, true);
+            (PidParameters results_withDelay, double[,] U_withDelay) = IdentifyInternal(dataSet, true, ignoreFlatLines: ignoreFlatLinesFirst);
    
             if (doOnlyWithDelay)
             {

--- a/Dynamic/UnitSimulator/UnitDataSet.cs
+++ b/Dynamic/UnitSimulator/UnitDataSet.cs
@@ -402,6 +402,116 @@ namespace TimeSeriesAnalysis.Dynamic
             }
             return averages.ToArray();
         }
+        /// <summary>
+        /// Identify the oversampled factor of the dataset. The oversamples need to be evenly spread in the dataset.
+        /// Subsets of oversamples in an otherwise non-oversampled dataset will not be taken into account here.
+        /// </summary>
+        /// <returns>the average distance between two unique values in the dataset arrays and a key index where the first new value occurs</returns>
+        public double GetOversampledFactor(out int keyIndex)
+        {
+            // Find the indices where all dataset arrays have the same value as the previous index
+            var vec = new Vec();
+            List<int> indOversampled = vec.FindValues(Y_meas, -9999, VectorFindValueType.SameAsPrevious);
+            for (int idx = 0; idx < U.GetNColumns(); idx++)
+            {
+                List<int> indSameU = vec.FindValues(U.GetColumn(idx), -9999, VectorFindValueType.SameAsPrevious);
+                indOversampled = indOversampled.Intersect(indSameU).ToList();
+            }
+
+            if (indOversampled.Count() < 2)
+            {
+                keyIndex = 0;
+                return 1;
+            }
+            
+            // Find the initial oversampled factor
+            int N = GetNumDataPoints();
+            double oversampledFactor = (double)N / (double)(N - indOversampled.Count());
+            if (oversampledFactor <= 1)
+            {
+                keyIndex = 0;
+                return 1;
+            }
+
+            // Check if the floor of the oversampled factor equals the size of smallest group of consecutive oversampled signals.
+            // Also find the best key index to use for downsampling.
+            // Sort the oversampled index vector.
+            indOversampled.Sort();
+
+            // Initialize counters
+            int consecutiveOversamples = 1;
+            var consecutiveOversamplesList = new List<int>();
+            int mostConsecutiveOversamples = 1;
+            int largestIndexDiff = indOversampled[1] - indOversampled[0];
+            int secondLargestIndexDiff = indOversampled[1] - indOversampled[0];
+            int consecutiveLargeIndexDiffs = 1;
+            int mostConsecutiveLargeIndexDiffs = 0;
+            int consecutiveLargeIndexDiffsStartIndex = indOversampled[0] + 1;
+            var consecutiveLargeIndexDiffsStartIndexList = new List<int>();
+            int mostConsecutiveLargeIndexDiffsStartIndex = indOversampled[0] + 1;
+
+            // Loop over the oversampled indices
+            for (int idx = 1; idx < indOversampled.Count(); idx++)
+            {
+                int indexDiff = indOversampled[idx] - indOversampled[idx-1];
+                if (indexDiff == 1)
+                {
+                    consecutiveOversamples++;
+                    if (consecutiveOversamples > mostConsecutiveOversamples)
+                    {
+                        mostConsecutiveOversamples = consecutiveOversamples;
+                    }
+                }
+                else
+                {
+                    if (indexDiff > largestIndexDiff)
+                    {
+                        secondLargestIndexDiff = largestIndexDiff;
+                        largestIndexDiff = indexDiff;
+                        consecutiveLargeIndexDiffsStartIndex = indOversampled[idx - 1] + 1;
+                        mostConsecutiveLargeIndexDiffsStartIndex = indOversampled[idx - 1] + 1;
+                        consecutiveLargeIndexDiffsStartIndexList.Add(consecutiveLargeIndexDiffsStartIndex);
+                        consecutiveLargeIndexDiffs = 1;
+                        mostConsecutiveLargeIndexDiffs = 1;
+                    }
+                    else if (indexDiff == largestIndexDiff)
+                    {
+                        consecutiveLargeIndexDiffs++;
+                        consecutiveLargeIndexDiffsStartIndexList.Add(consecutiveLargeIndexDiffsStartIndex);
+                        if (consecutiveLargeIndexDiffs > mostConsecutiveLargeIndexDiffs)
+                        {
+                            mostConsecutiveLargeIndexDiffs = consecutiveLargeIndexDiffs;
+                            mostConsecutiveLargeIndexDiffsStartIndex = consecutiveLargeIndexDiffsStartIndex;
+                        }
+                    }
+                    else
+                    {
+                        if (indexDiff > secondLargestIndexDiff)
+                        {
+                            secondLargestIndexDiff = indexDiff;
+                        }
+                        consecutiveLargeIndexDiffsStartIndexList.Add(consecutiveLargeIndexDiffsStartIndex);
+                        consecutiveLargeIndexDiffs = 0;
+                        consecutiveLargeIndexDiffsStartIndex = indOversampled[idx] + 1;
+                    }
+                    consecutiveOversamplesList.Add(consecutiveOversamples);
+                    consecutiveOversamples = 1;
+                }
+            }
+
+            // Return the oversampled factor, or 1 if no evenly spread oversampling is found.
+            if ((mostConsecutiveOversamples + 1 == (int)Math.Ceiling(oversampledFactor)) & 
+                (largestIndexDiff - secondLargestIndexDiff < 3))
+            {
+                keyIndex = mostConsecutiveLargeIndexDiffsStartIndex;
+                return oversampledFactor;
+            }
+            else
+            {
+                keyIndex = 0;
+                return 1;
+            }
+        }
 
         /// <summary>
         /// Helper to set column of U to uValues. 

--- a/TimeSeriesAnalysis.Tests/Test/SysID/PidIdentUnitTests.cs
+++ b/TimeSeriesAnalysis.Tests/Test/SysID/PidIdentUnitTests.cs
@@ -305,7 +305,7 @@ namespace TimeSeriesAnalysis.Test.SysID
             // Identify model on oversampled data
             var pidDataSetOversampled_control = processSim.GetUnitDataSetForPID(combinedDataOversampled, pidModel1);
             var pidDataSetOversampled = processSim.GetUnitDataSetForPID(combinedDataOversampled, pidModel1);
-            var oversampledModelParameters_control = new PidIdentifier().Identify(ref pidDataSetOversampled_control, downsampleOversampledData: false);
+            var oversampledModelParameters_control = new PidIdentifier().Identify(ref pidDataSetOversampled_control, downsampleOversampledData: false, ignoreFlatLines: false);
             var oversampledModelParameters = new PidIdentifier().Identify(ref pidDataSetOversampled);
 
             // Plot results
@@ -393,7 +393,7 @@ namespace TimeSeriesAnalysis.Test.SysID
             // Identify model on oversampled data
             var pidDataSetOversampled_control = processSim.GetUnitDataSetForPID(combinedDataOversampled, pidModel1);
             var pidDataSetOversampled = processSim.GetUnitDataSetForPID(combinedDataOversampled, pidModel1);
-            var oversampledModelParameters_control = new PidIdentifier().Identify(ref pidDataSetOversampled_control, downsampleOversampledData: false);
+            var oversampledModelParameters_control = new PidIdentifier().Identify(ref pidDataSetOversampled_control, downsampleOversampledData: false, ignoreFlatLines: false);
             var oversampledModelParameters = new PidIdentifier().Identify(ref pidDataSetOversampled);
 
             // Plot results

--- a/TimeSeriesAnalysis.Tests/Test/SysID/PidIdentUnitTests.cs
+++ b/TimeSeriesAnalysis.Tests/Test/SysID/PidIdentUnitTests.cs
@@ -251,6 +251,24 @@ namespace TimeSeriesAnalysis.Test.SysID
         }
 
 
+        /// <summary>
+        /// It is not uncommon for datasets to be oversampled from the resolution of the stored timeseries.
+        /// The identification should then automatically attempt downsampling to improve the fitscore.
+        /// </summary>
+        /// <param name="N">number of samples in the stored dataset,</param>
+        /// <param name="timebaseStored">Timebase of the stored signals.</param>
+        /// <param name="timebaseOversampled">Timebase of the oversampled data.</param>
+        [TestCase(1000,50.0,1.0)]// the stored signal is oversampled by a factor 50
+        [TestCase(1000,50.0,7.0)]// the stored signal is oversampled by a factor 50/7
+        [TestCase(1000,50.0,37.0)]// the stored signal is oversampled by a factor 50/37
+        [TestCase(1000,10.0,1.0)]// the stored signal is oversampled by a factor 10
+        [TestCase(1000,10.0,2.0)]// the stored signal is oversampled by a factor 5
+        [TestCase(1000,10.0,3.0)]// the stored signal is oversampled by a factor 10/3
+        [TestCase(1000,10.0,4.0)]// the stored signal is oversampled by a factor 2.5
+        [TestCase(1000,10.0,5.0)]// the stored signal is oversampled by a factor 2
+        [TestCase(1000,7.0,4.0)]// the stored signal is oversampled by a factor 7/4
+        [TestCase(1000,5.0,3.0)]// the stored signal is oversampled by a factor 5/3
+        [TestCase(1000,5.0,4.0)]// the stored signal is oversampled by a factor 1.25
         public void DownsampleOversampledData(int N, double timebaseStored, double timebaseOversampled)
         {
             // Define parameters
@@ -404,49 +422,7 @@ namespace TimeSeriesAnalysis.Test.SysID
             Assert.IsTrue((oversampledModelParameters.Fitting.FitScorePrc > 0.9 * oversampledModelParameters_control.Fitting.FitScorePrc) | (oversampledModelParameters.Fitting.RsqDiff > 0.9 * oversampledModelParameters_control.Fitting.RsqDiff)); // Allow a little slack due to noise effects
         }
 
-        /// <summary>
-        /// A comprehensive case can include situations where both noise, downsampling, oversampling, and data loss
-        /// occurs in the same dataset. These tests ensure that the identification is able to find the key parameters
-        /// in such situations as well.
-        /// </summary>
-        /// <param name="N">number of samples in the original dataset.</param>
-        /// <param name="timebaseOriginal">Timebase of the original signals.</param>
-        /// <param name="timebaseStored">Timebase of the stored signals.</param>
-        /// <param name="timebaseOversampled">Timebase of the oversampled data.</param>
-        /// <param name="flatlinePeriods">Number of periods with flatlined data.</param>
-        /// <param name="flatlineProportion">Proportion of the dataset that should be flatlines.</param>
-        [TestCase(10000,1.0,8.0,2.0,1,0.1)]
-        [TestCase(10000,1.0,8.0,2.0,1,0.25)]
-        [TestCase(10000,1.0,8.0,2.0,4,0.1)]
-        [TestCase(10000,1.0,8.0,2.0,4,0.25)]
-        [TestCase(10000,1.0,8.0,5.0,1,0.1)]
-        [TestCase(10000,1.0,8.0,5.0,1,0.25)]
-        [TestCase(10000,1.0,8.0,5.0,4,0.1)]
-        [TestCase(10000,1.0,8.0,5.0,4,0.25)]
-        [TestCase(10000,1.0,15.0,2.0,1,0.1)]
-        [TestCase(10000,1.0,15.0,2.0,1,0.25)]
-        [TestCase(10000,1.0,15.0,2.0,4,0.1)]
-        [TestCase(10000,1.0,15.0,2.0,4,0.25)]
-        [TestCase(10000,1.0,15.0,5.0,1,0.1)]
-        [TestCase(10000,1.0,15.0,5.0,1,0.25)]
-        [TestCase(10000,1.0,15.0,5.0,4,0.1)]
-        [TestCase(10000,1.0,15.0,5.0,4,0.25)]
-        [TestCase(10000,3.0,8.0,2.0,1,0.1)]
-        [TestCase(10000,3.0,8.0,2.0,1,0.25)]
-        [TestCase(10000,3.0,8.0,2.0,4,0.1)]
-        [TestCase(10000,3.0,8.0,2.0,4,0.25)]
-        [TestCase(10000,3.0,8.0,5.0,1,0.1)]
-        [TestCase(10000,3.0,8.0,5.0,1,0.25)]
-        [TestCase(10000,3.0,8.0,5.0,4,0.1)]
-        [TestCase(10000,3.0,8.0,5.0,4,0.25)]
-        [TestCase(10000,3.0,15.0,2.0,1,0.1)]
-        [TestCase(10000,3.0,15.0,2.0,1,0.25)]
-        [TestCase(10000,3.0,15.0,2.0,4,0.1)]
-        [TestCase(10000,3.0,15.0,2.0,4,0.25)]
-        [TestCase(10000,3.0,15.0,5.0,1,0.1)]
-        [TestCase(10000,3.0,15.0,5.0,1,0.25)]
-        [TestCase(10000,3.0,15.0,5.0,4,0.1)]
-        [TestCase(10000,3.0,15.0,5.0,4,0.25)]
+       
 
 
 

--- a/TimeSeriesAnalysis/TimeSeriesDataSet.cs
+++ b/TimeSeriesAnalysis/TimeSeriesDataSet.cs
@@ -336,6 +336,25 @@ namespace TimeSeriesAnalysis
         }
 
         /// <summary>
+        /// Returns a copy of the dataset that is oversampled by the given factor.
+        /// </summary>
+        /// <param name="oversampleFactor">value greater than 1 indicating that every value will be sampled until (i / factor > 1).</param>
+        /// <param name="keyIndex">optional index around which to perform the oversampling.</param>
+        /// <returns></returns>
+        public TimeSeriesDataSet CreateOversampledCopy(double oversampleFactor, int keyIndex = 0)
+        {
+            TimeSeriesDataSet ret = new TimeSeriesDataSet();
+
+            ret.CreateTimestamps(timeBase_s: GetTimeBase() / oversampleFactor, N: (int)Math.Ceiling(GetNumDataPoints() * oversampleFactor), t0: timeStamps[0]);
+            ret.dataset_constants = dataset_constants;
+            foreach (var item in dataset)
+            {
+                ret.dataset[item.Key] = Vec<double>.Oversample(item.Value, oversampleFactor, keyIndex);
+            }
+            return ret;
+        }
+
+        /// <summary>
         /// Creates internal timestamps from a given start time and timebase, must be called after filling the values 
         /// </summary>
         /// <param name="timeBase_s">the time between samples in the dataset, in total seconds</param>

--- a/TimeSeriesAnalysis/Vec.cs
+++ b/TimeSeriesAnalysis/Vec.cs
@@ -382,6 +382,14 @@ namespace TimeSeriesAnalysis
                         Add(i);//indices.Add(i);
                 }
             }
+            else if (type == VectorFindValueType.SameAsPrevious)
+            {
+                for (int i = 1; i < vec.Length; i++)
+                {
+                    if (vec[i] == vec[i-1])
+                        Add(i);//indices.Add(i);
+                }
+            }
             return indices;
         }
 

--- a/TimeSeriesAnalysis/VecEnums.cs
+++ b/TimeSeriesAnalysis/VecEnums.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -42,7 +42,11 @@ namespace TimeSeriesAnalysis
         /// <summary>
         /// Find values that are NOT equal to a given value
         /// </summary>
-        NotEqual = 8
+        NotEqual = 8,
+        /// <summary>
+        /// Find values that are equal to the previous index value
+        /// </summary>
+        SameAsPrevious = 9
 
 
     }

--- a/TimeSeriesAnalysis/VecGeneric.cs
+++ b/TimeSeriesAnalysis/VecGeneric.cs
@@ -86,6 +86,45 @@ namespace TimeSeriesAnalysis
             return ret.ToArray();
         }
 
+        /// <summary>
+        /// Oversample a vector by a given factor by choosing every value until (i/factor > 1).
+        /// The optional key index indicates an index for which to base the oversampling around.
+        /// </summary>
+        /// <param name="vec"></param>
+        /// <param name="factor"></param>
+        /// <param name="keyIndex"></param>
+        /// <returns></returns>
+        static public T[] Oversample(T[] vec, double factor, int keyIndex = 0)
+        {
+            if (vec == null)
+                return null;
+            if (factor <= 1)
+                return vec;
+
+            // Find oversampled indices
+            var ind = new List<int>();
+            int count = 0;
+            for (int i = keyIndex; i >= 0; i = keyIndex - (int)Math.Ceiling(count / factor))
+            {
+                ind.Add(i);
+                count++;
+            }
+            count = 1;
+            for (int i = keyIndex + (int)Math.Floor(1 / factor); i < vec.Length; i = keyIndex + (int)Math.Floor(count / factor))
+            {
+                ind.Add(i);
+                count++;
+            }
+            ind.Sort();
+
+            // Populate and return oversampled vector
+            var ret = new List<T>();
+            for (int i = 0; i < ind.Count(); i++)
+            {
+                ret.Add(vec[ind[i]]);
+            }
+            return ret.ToArray();
+        }
 
         ///<summary>
         /// creates an array of size N where every element has value value


### PR DESCRIPTION
**Comprehensive pull request for handling oversampled data**

- A method for finding the oversampled factor of a dataset is added. For generality, non-integer oversample factors are assumed, with a method for discovering the key index to use for downsampling the dataset.
- A method for finding oversampled indices is added to be able to add such indices to the IndicesToIgnore list. PidIdentifier has implemented this in its IndicesToIgnore-population.
- The timeseries creator has an added method for oversampling a dataset.
- PidIdentifier has been modified to be able to identify oversampling, rerun the identify method on a downsampled dataset, and return whichever model yields the best fit.
- Tests have been added to test the automatic downsampling of oversampled datasets.