### PR TITLE
Add flatline data handling and comprehensive tests.

### DIFF
--- a/TimeSeriesAnalysis.Tests/Test/SysID/PidIdentUnitTests.cs
+++ b/TimeSeriesAnalysis.Tests/Test/SysID/PidIdentUnitTests.cs
@@ -250,6 +250,102 @@ namespace TimeSeriesAnalysis.Test.SysID
 
         }
 
+        /// <summary>
+        /// It is not uncommon for datasets to have flatlines for various reasons. Such periods should be filtered out in the indicesToIgnore.
+        /// </summary>
+        /// <param name="N">number of samples in the stored dataset,</param>
+        /// <param name="timebase">Timebase of the signals.</param>
+        /// <param name="flatlinePeriods">Number of periods with flatlined data.</param>
+        /// <param name="flatlineProportion">Proportion of the dataset that should be flatlines.</param>
+        [TestCase(1000,10.0,1,0.1)]// There is one flatline period covering 10%.
+        [TestCase(1000,10.0,1,0.25)]// There is one flatline period covering 25%.
+        [TestCase(1000,10.0,2,0.1)]// There are two flatline periods covering 10%.
+        [TestCase(1000,10.0,2,0.25)]// There are two flatline periods covering 25%.
+        [TestCase(1000,10.0,3,0.1)]// There are three flatline periods covering 10%.
+        [TestCase(1000,10.0,3,0.25)]// There are three flatline periods covering 25%.
+        [TestCase(1000,10.0,4,0.1)]// There are four flatline periods covering 10%.
+        [TestCase(1000,10.0,4,0.25)]// There are four flatline periods covering 25%.
+        public void IndicesToIgnore_WFlatLines(int N, double timebase, int flatlinePeriods, double flatlineProportion)
+        {
+            // Define parameters
+            var pidParameters1 = new PidParameters()
+            {
+                Kp = 0.5,
+                Ti_s = 50
+            };
+
+            // Create plant model
+            var pidModel1 = new PidModel(pidParameters1, "PID1");
+            var processSim = new PlantSimulator(
+            new List<ISimulatableModel> { pidModel1, processModel1 });
+            processSim.ConnectModels(processModel1, pidModel1);
+            processSim.ConnectModels(pidModel1, processModel1);
+
+            // Create synthetic data
+            var inputData = new TimeSeriesDataSet();
+            inputData.Add(processSim.AddExternalSignal(pidModel1, SignalType.Setpoint_Yset), TimeSeriesCreator.Constant(50, N));
+            inputData.Add(processSim.AddExternalSignal(processModel1, SignalType.Disturbance_D), TimeSeriesCreator.Sinus(10, timebase*20, timebase, N));
+            inputData.CreateTimestamps(timebase);
+            var isOk = processSim.Simulate(inputData, out TimeSeriesDataSet simData);
+            var combinedData = inputData.Combine(simData);
+            var pidDataSet = processSim.GetUnitDataSetForPID(combinedData, pidModel1);
+
+            // Create synthetic data with flatlines (Create them anew to avoid shallow copies / references)
+            int flatlinePeriodLength = (int)(flatlineProportion * N / flatlinePeriods);
+            var inputDataFlatlines = new TimeSeriesDataSet();
+            inputDataFlatlines.Add(processSim.AddExternalSignal(pidModel1, SignalType.Setpoint_Yset), TimeSeriesCreator.Constant(50, N));
+            inputDataFlatlines.Add(processSim.AddExternalSignal(processModel1, SignalType.Disturbance_D), TimeSeriesCreator.Sinus(10, timebase*20, timebase, N));
+            inputDataFlatlines.CreateTimestamps(timebase);
+            var isOkFlatlines = processSim.Simulate(inputDataFlatlines, out TimeSeriesDataSet simDataFlatlines);
+            var combinedDataFlatlines = inputDataFlatlines.Combine(simDataFlatlines);
+            var pidDataSetWithFlatlines_control = processSim.GetUnitDataSetForPID(combinedDataFlatlines, pidModel1);
+            var pidDataSetWithFlatlines = processSim.GetUnitDataSetForPID(combinedDataFlatlines, pidModel1);
+            for (int i = 0; i < flatlinePeriods; i++)
+            {
+                int flatlineStartIndex = (int)(N * ((double)i + 0.5) / flatlinePeriods - flatlinePeriodLength / 2);
+                for (int j = 1; j < flatlinePeriodLength; j++)
+                {
+                    pidDataSetWithFlatlines_control.U[flatlineStartIndex + j, 0] = pidDataSetWithFlatlines_control.U[flatlineStartIndex, 0];
+                    pidDataSetWithFlatlines_control.Y_meas[flatlineStartIndex + j] = pidDataSetWithFlatlines_control.Y_meas[flatlineStartIndex];
+                    pidDataSetWithFlatlines_control.Y_setpoint[flatlineStartIndex + j] = pidDataSetWithFlatlines_control.Y_setpoint[flatlineStartIndex];
+                    pidDataSetWithFlatlines.U[flatlineStartIndex + j, 0] = pidDataSetWithFlatlines.U[flatlineStartIndex, 0];
+                    pidDataSetWithFlatlines.Y_meas[flatlineStartIndex + j] = pidDataSetWithFlatlines.Y_meas[flatlineStartIndex];
+                    pidDataSetWithFlatlines.Y_setpoint[flatlineStartIndex + j] = pidDataSetWithFlatlines.Y_setpoint[flatlineStartIndex];
+                }
+            }
+
+            // Identify on both original and flatlined datasets
+            var modelParameters = new PidIdentifier().Identify(ref pidDataSet);
+            var modelParametersWithFlatlines_control = new PidIdentifier().Identify(ref pidDataSetWithFlatlines_control, ignoreFlatLines: false);
+            var modelParametersWithFlatlines = new PidIdentifier().Identify(ref pidDataSetWithFlatlines);
+
+            // Plot results
+            if (false)
+            {
+                Shared.EnablePlots();
+                string caseId = TestContext.CurrentContext.Test.Name.Replace("(", "_").
+                    Replace(")", "_").Replace(",", "_") + "y";
+                Plot.FromList(new List<double[]>{ pidDataSet.Y_meas, pidDataSet.Y_setpoint, pidDataSet.U.GetColumn(0), pidDataSet.U_sim.GetColumn(0)},
+                    new List<string> { "y1=y_meas", "y1=y_setpoint", "y3=u", "y3=u_sim" },
+                    pidDataSet.GetTimeBase(), caseId+"_raw");
+                Plot.FromList(new List<double[]>{ pidDataSetWithFlatlines.Y_meas, pidDataSetWithFlatlines.Y_setpoint, pidDataSetWithFlatlines.U.GetColumn(0), pidDataSetWithFlatlines.U_sim.GetColumn(0)},
+                    new List<string> { "y1=y_meas_with_flatlines", "y1=y_setpoint_with_flatlines", "y3=u_with_flatlines", "y3=u_sim_with_flatlines" },
+                    pidDataSetWithFlatlines.GetTimeBase(), caseId+"_with_flatlines");
+                Shared.DisablePlots();
+            }
+
+            // Assert that identification on datasets with flatlines yields the same parameters as identification on original data
+            // and check that it also finds parameters that are somewhat close to the original values.
+            // Also assert that the identification yields better fits when attempting to ignore flatlines than when not doing so.
+            // Finally, assert that the fit is better when taking flatline handling into account.
+            Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Kp - modelParameters.Kp) < 0.02 * modelParametersWithFlatlines.Kp); // Allow 2% slack on Ti
+            Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Ti_s - modelParameters.Ti_s) < 0.05 * modelParametersWithFlatlines.Ti_s); // Allow 5% slack on Ti
+            Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Kp - pidParameters1.Kp) < 0.02 * pidParameters1.Kp); // Allow 2% slack on Ti
+            Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Ti_s - pidParameters1.Ti_s) < 0.05 * pidParameters1.Ti_s); // Allow 5% slack on Ti
+            Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Kp - pidParameters1.Kp) < Math.Abs(modelParametersWithFlatlines_control.Kp - pidParameters1.Kp));
+            Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Ti_s - pidParameters1.Ti_s) < Math.Abs(modelParametersWithFlatlines_control.Ti_s - pidParameters1.Ti_s));
+            Assert.IsTrue((modelParametersWithFlatlines.Fitting.FitScorePrc > modelParametersWithFlatlines_control.Fitting.FitScorePrc) | (modelParametersWithFlatlines.Fitting.RsqDiff > modelParametersWithFlatlines_control.Fitting.RsqDiff));
+        }
 
         /// <summary>
         /// It is not uncommon for datasets to be oversampled from the resolution of the stored timeseries.
@@ -421,8 +517,148 @@ namespace TimeSeriesAnalysis.Test.SysID
             Assert.IsTrue(Math.Abs(oversampledModelParameters.Ti_s - pidParameters1.Ti_s) < Math.Abs(oversampledModelParameters_control.Ti_s - pidParameters1.Ti_s));
             Assert.IsTrue((oversampledModelParameters.Fitting.FitScorePrc > 0.9 * oversampledModelParameters_control.Fitting.FitScorePrc) | (oversampledModelParameters.Fitting.RsqDiff > 0.9 * oversampledModelParameters_control.Fitting.RsqDiff)); // Allow a little slack due to noise effects
         }
+        /// <summary>
+        /// A comprehensive case can include situations where both noise, downsampling, oversampling, and data loss
+        /// occurs in the same dataset. These tests ensure that the identification is able to find the key parameters
+        /// in such situations as well.
+        /// </summary>
+        /// <param name="N">number of samples in the original dataset.</param>
+        /// <param name="timebaseOriginal">Timebase of the original signals.</param>
+        /// <param name="timebaseStored">Timebase of the stored signals.</param>
+        /// <param name="timebaseOversampled">Timebase of the oversampled data.</param>
+        /// <param name="flatlinePeriods">Number of periods with flatlined data.</param>
+        /// <param name="flatlineProportion">Proportion of the dataset that should be flatlines.</param>
+        [TestCase(10000,1.0,8.0,2.0,1,0.1)]
+        [TestCase(10000,1.0,8.0,2.0,1,0.25)]
+        [TestCase(10000,1.0,8.0,2.0,4,0.1)]
+        [TestCase(10000,1.0,8.0,2.0,4,0.25)]
+        [TestCase(10000,1.0,8.0,5.0,1,0.1)]
+        [TestCase(10000,1.0,8.0,5.0,1,0.25)]
+        [TestCase(10000,1.0,8.0,5.0,4,0.1)]
+        [TestCase(10000,1.0,8.0,5.0,4,0.25)]
+        [TestCase(10000,1.0,15.0,2.0,1,0.1)]
+        [TestCase(10000,1.0,15.0,2.0,1,0.25)]
+        [TestCase(10000,1.0,15.0,2.0,4,0.1)]
+        [TestCase(10000,1.0,15.0,2.0,4,0.25)]
+        [TestCase(10000,1.0,15.0,5.0,1,0.1)]
+        [TestCase(10000,1.0,15.0,5.0,1,0.25)]
+        [TestCase(10000,1.0,15.0,5.0,4,0.1)]
+        [TestCase(10000,1.0,15.0,5.0,4,0.25)]
+        [TestCase(10000,3.0,8.0,2.0,1,0.1)]
+        [TestCase(10000,3.0,8.0,2.0,1,0.25)]
+        [TestCase(10000,3.0,8.0,2.0,4,0.1)]
+        [TestCase(10000,3.0,8.0,2.0,4,0.25)]
+        [TestCase(10000,3.0,8.0,5.0,1,0.1)]
+        [TestCase(10000,3.0,8.0,5.0,1,0.25)]
+        [TestCase(10000,3.0,8.0,5.0,4,0.1)]
+        [TestCase(10000,3.0,8.0,5.0,4,0.25)]
+        [TestCase(10000,3.0,15.0,2.0,1,0.1)]
+        [TestCase(10000,3.0,15.0,2.0,1,0.25)]
+        [TestCase(10000,3.0,15.0,2.0,4,0.1)]
+        [TestCase(10000,3.0,15.0,2.0,4,0.25)]
+        [TestCase(10000,3.0,15.0,5.0,1,0.1)]
+        [TestCase(10000,3.0,15.0,5.0,1,0.25)]
+        [TestCase(10000,3.0,15.0,5.0,4,0.1)]
+        [TestCase(10000,3.0,15.0,5.0,4,0.25)]
+        public void DownsampleOversampledDownsampledData_WNoise_WFlatLines(int N, double timebaseOriginal, double timebaseStored, double timebaseOversampled, int flatlinePeriods, double flatlineProportion)
+        {
+            // Define parameters
+            var pidParameters1 = new PidParameters()
+            {
+                Kp = 0.2,
+                Ti_s = timebaseOriginal*60
+            };
 
-       
+            double downsampleFactor = timebaseStored / timebaseOriginal;
+            double oversampleFactor = timebaseStored / timebaseOversampled;
+            double noiseAmplitude = 1;
+
+            // Create plant model
+            var pidModel1 = new PidModel(pidParameters1, "PID1");
+            var processSim = new PlantSimulator(
+            new List<ISimulatableModel> { pidModel1, processModel1 });
+            processSim.ConnectModels(processModel1, pidModel1);
+            processSim.ConnectModels(pidModel1, processModel1);
+
+            // Create synthetic data
+            var inputData = new TimeSeriesDataSet();
+            inputData.Add(processSim.AddExternalSignal(pidModel1, SignalType.Setpoint_Yset), TimeSeriesCreator.Constant(50, N));
+            inputData.Add(processSim.AddExternalSignal(processModel1, SignalType.Disturbance_D), TimeSeriesCreator.Sinus(10, timebaseOriginal*100, timebaseOriginal, N));
+            inputData.CreateTimestamps(timebaseOriginal);
+            var isOk = processSim.Simulate(inputData, out TimeSeriesDataSet simData);
+
+            // Add noise to measured data
+            simData.AddNoiseToSignal("SubProcess1-Output_Y", noiseAmplitude,123456);
+
+            // Identify the model on original, high-resolution data
+            var combinedData = inputData.Combine(simData);
+            var pidDataSet = processSim.GetUnitDataSetForPID(combinedData, pidModel1);
+
+            // The stored signal is then downsampled to a lower, stored resolution
+            var combinedDataDownsampled = combinedData.CreateDownsampledCopy(downsampleFactor);
+            var pidDataSetDownsampled = processSim.GetUnitDataSetForPID(combinedDataDownsampled, pidModel1);
+
+            // At some point these signals are oversampled
+            var combinedDataDownsampledOversampled = combinedDataDownsampled.CreateOversampledCopy(oversampleFactor);
+            var pidDataSetDownsampledOversampled = processSim.GetUnitDataSetForPID(combinedDataDownsampledOversampled, pidModel1);
+
+            // Something occurs somewhere along the way, causing sporadic data loss
+            // Recreate data to avoid shallow copies
+            var inputDataWithFlatlines = new TimeSeriesDataSet();
+            inputDataWithFlatlines.Add(processSim.AddExternalSignal(pidModel1, SignalType.Setpoint_Yset), TimeSeriesCreator.Constant(50, N));
+            inputDataWithFlatlines.Add(processSim.AddExternalSignal(processModel1, SignalType.Disturbance_D), TimeSeriesCreator.Sinus(10, timebaseOriginal*100, timebaseOriginal, N));
+            inputDataWithFlatlines.CreateTimestamps(timebaseOriginal);
+            var isOkWithFlatlines = processSim.Simulate(inputDataWithFlatlines, out TimeSeriesDataSet simDataWithFlatlines);
+            simDataWithFlatlines.AddNoiseToSignal("SubProcess1-Output_Y", noiseAmplitude,123456);
+            var combinedDataWithFlatlines = inputData.Combine(simDataWithFlatlines);
+            var combinedDataDownsampledWithFlatlines = combinedDataWithFlatlines.CreateDownsampledCopy(downsampleFactor);
+            var combinedDataDownsampledOversampledWithFlatlines = combinedDataDownsampledWithFlatlines.CreateOversampledCopy(oversampleFactor);
+            var pidDataSetDownsampledOversampledWithFlatlines = processSim.GetUnitDataSetForPID(combinedDataDownsampledOversampledWithFlatlines, pidModel1);
+
+            int N_downsampled_oversampled = pidDataSetDownsampledOversampled.Y_meas.Count();
+            int flatlinePeriodLength = (int)(flatlineProportion * N_downsampled_oversampled / flatlinePeriods);
+            for (int i = 0; i < flatlinePeriods; i++)
+            {
+                int flatlineStartIndex = (int)(N_downsampled_oversampled * ((double)i + 0.5) / flatlinePeriods - flatlinePeriodLength / 2);
+                for (int j = 1; j < flatlinePeriodLength; j++)
+                {
+                    pidDataSetDownsampledOversampledWithFlatlines.U[flatlineStartIndex + j, 0] = pidDataSetDownsampledOversampledWithFlatlines.U[flatlineStartIndex, 0];
+                    pidDataSetDownsampledOversampledWithFlatlines.Y_meas[flatlineStartIndex + j] = pidDataSetDownsampledOversampledWithFlatlines.Y_meas[flatlineStartIndex];
+                    pidDataSetDownsampledOversampledWithFlatlines.Y_setpoint[flatlineStartIndex + j] = pidDataSetDownsampledOversampledWithFlatlines.Y_setpoint[flatlineStartIndex];
+                }
+            }
+            var modelParametersOriginal = new PidIdentifier().Identify(ref pidDataSet);
+            var modelParametersDownsampled = new PidIdentifier().Identify(ref pidDataSetDownsampled);
+            var modelParametersDownsampledOversampled = new PidIdentifier().Identify(ref pidDataSetDownsampledOversampled);
+            var modelParametersDownsampledOversampledWithFlatlines = new PidIdentifier().Identify(ref pidDataSetDownsampledOversampledWithFlatlines);
+
+            // Plot results
+            if (false)
+            {
+                Shared.EnablePlots();
+                string caseId = TestContext.CurrentContext.Test.Name.Replace("(", "_").
+                    Replace(")", "_").Replace(",", "_") + "y";
+                Plot.FromList(new List<double[]>{ pidDataSet.Y_meas, pidDataSet.Y_setpoint, pidDataSet.U.GetColumn(0), pidDataSet.U_sim.GetColumn(0)},
+                    new List<string> { "y1=y_meas", "y1=y_setpoint", "y3=u", "y3=u_sim" },
+                    pidDataSet.GetTimeBase(), caseId+"_raw");
+                Plot.FromList(new List<double[]>{ pidDataSetDownsampled.Y_meas, pidDataSetDownsampled.Y_setpoint, pidDataSetDownsampled.U.GetColumn(0), pidDataSetDownsampled.U_sim.GetColumn(0)},
+                    new List<string> { "y1=y_meas_downsampled", "y1=y_setpoint_downsampled", "y3=u_downsampled", "y3=u_sim_downsampled" },
+                    pidDataSetDownsampled.GetTimeBase(), caseId+"_downsampled");
+                Plot.FromList(new List<double[]>{ pidDataSetDownsampledOversampled.Y_meas, pidDataSetDownsampledOversampled.Y_setpoint, pidDataSetDownsampledOversampled.U.GetColumn(0), pidDataSetDownsampledOversampled.U_sim.GetColumn(0)},
+                    new List<string> { "y1=y_meas_downsampled_oversampled", "y1=y_setpoint_downsampled_oversampled", "y3=u_downsampled_oversampled", "y3=u_sim_downsampled_oversampled" },
+                    pidDataSetDownsampledOversampled.GetTimeBase(), caseId+"_downsampled_oversampled");
+                Plot.FromList(new List<double[]>{ pidDataSetDownsampledOversampledWithFlatlines.Y_meas, pidDataSetDownsampledOversampledWithFlatlines.Y_setpoint, pidDataSetDownsampledOversampledWithFlatlines.U.GetColumn(0), pidDataSetDownsampledOversampledWithFlatlines.U_sim.GetColumn(0)},
+                    new List<string> { "y1=y_meas_downsampled_oversampled_withFlatlines", "y1=y_setpoint_downsampled_oversampled_withFlatlines", "y3=u_downsampled_oversampled_withFlatlines", "y3=u_sim_downsampled_oversampled_withFlatlines" },
+                    pidDataSetDownsampledOversampledWithFlatlines.GetTimeBase(), caseId+"_downsampled_oversampled_withFlatlines");
+                Shared.DisablePlots();
+            }
+
+            // Assert that the identification on the final dataset is able to approximately identify the parameters of the original data
+            // This is a case where the original dataset is significantly altered before identification, so significant slack is allowed for now.
+            Assert.IsTrue(Math.Abs(modelParametersDownsampledOversampledWithFlatlines.Kp - pidParameters1.Kp) < 0.15 * pidParameters1.Kp);
+            Assert.IsTrue(Math.Abs(modelParametersDownsampledOversampledWithFlatlines.Ti_s - pidParameters1.Ti_s) < 0.2 * pidParameters1.Ti_s);
+            Assert.IsTrue(Math.Abs(modelParametersDownsampledOversampledWithFlatlines.Fitting.TimeBase_s - modelParametersOriginal.Fitting.TimeBase_s * downsampleFactor) < 0.85 * modelParametersOriginal.Fitting.TimeBase_s * downsampleFactor);
+        }
 
 
 


### PR DESCRIPTION
For cases when the data has sporadic, missing periods, but is still sampled with the same frequency, there will be sections of 'flatlined' data. This is handled as "bad data" using the oversampled identification for IndicesToIgnore in some cases, but not if the base dataset is also oversampled. This pull request adds functionality to discover "flatline periods" during the calculation of the oversample factor. Such periods will be disregarded when finding the oversample factor, and the resulting downsampled dataset will work as normal through the IndicesToIgnore to disregard the "flatlines" themselves.

A test group for "just" datasets with flat data sprinkled around is included, as well as a quite comprehensive test set which includes both noise, downsampling, oversampling, and data loss before identification to test that all features function together.