### PR TITLE
Slight refactoring to optimize code

### DIFF
--- a/Dynamic/Identification/FitScoreCalculator.cs
+++ b/Dynamic/Identification/FitScoreCalculator.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -196,12 +196,20 @@ namespace TimeSeriesAnalysis
                 return double.NaN;
             double ret = 0;
             double N = 0;
+            indToIgnore?.Sort();
+            int indToIgnoreIndex = 0;
             for (var i = 0; i < Math.Min(reference.Length, model.Length); i++)
             {
-                if (indToIgnore != null)
+                if (!((indToIgnore == null) || (indToIgnore.Count == 0)))
                 {
-                    if (indToIgnore.Contains(i))
+                    if (i == indToIgnore[indToIgnoreIndex])
+                    {
+                        if (indToIgnoreIndex + 1 < indToIgnore.Count)
+                        {
+                            indToIgnoreIndex++;
+                        }
                         continue;
+                    }
                 }
                 ret += Math.Abs(reference[i] - model[i]);
                 N++;
@@ -225,12 +233,20 @@ namespace TimeSeriesAnalysis
 
             var N = 0;
             double ret = 0;
+            indToIgnore?.Sort();
+            int indToIgnoreIndex = 0;
             for (var i = 0; i < signal.Length; i++)
             {
-                if (indToIgnore != null)
+                if (!((indToIgnore == null) || (indToIgnore.Count == 0)))
                 {
-                    if (indToIgnore.Contains(i))
+                    if (i == indToIgnore[indToIgnoreIndex])
+                    {
+                        if (indToIgnoreIndex + 1 < indToIgnore.Count)
+                        {
+                            indToIgnoreIndex++;
+                        }
                         continue;
+                    }
                 }
                 ret += Math.Abs(signal[i] - avg.Value);
                 N++;

--- a/Dynamic/Identification/PidIdentifier.cs
+++ b/Dynamic/Identification/PidIdentifier.cs
@@ -1,4 +1,4 @@
-using Accord.Math;
+﻿using Accord.Math;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,7 +18,8 @@ namespace TimeSeriesAnalysis.Dynamic
     {
         private const double CUTOFF_FOR_GUESSING_PID_IN_MANUAL_FRAC = 0.005;
         const double rSquaredCutoffForInTrackingWarning = 0.02;//must be between 0 and 1
-
+        private const double MAX_RSQUARED_DIFF_BEFORE_COMPARING_FITSCORE = 95; // Must be below 100
+        private const double MIN_FITSCORE_DIFF_BEFORE_COMPARING_FITSCORE = 10; // Must be positive
         private const int MAX_ESTIMATIONS_PER_DATASET = 1;
         private const double MIN_DATASUBSET_URANGE_PRC = 0;
         private double badValueIndicatingValue;
@@ -51,7 +52,9 @@ namespace TimeSeriesAnalysis.Dynamic
         private bool IsFirstModelBetterThanSecondModel(PidParameters firstModel, PidParameters secondModel)
         {
             // If both models show a very high R-Squared-diff, look at fitscore instead if there is a significant difference
-            if (firstModel.Fitting.RsqDiff > 95 && secondModel.Fitting.RsqDiff > 95 && Math.Abs(firstModel.Fitting.FitScorePrc - secondModel.Fitting.FitScorePrc) > 10)
+            if (firstModel.Fitting.RsqDiff > MAX_RSQUARED_DIFF_BEFORE_COMPARING_FITSCORE
+                && secondModel.Fitting.RsqDiff > MAX_RSQUARED_DIFF_BEFORE_COMPARING_FITSCORE
+                && Math.Abs(firstModel.Fitting.FitScorePrc - secondModel.Fitting.FitScorePrc) > MIN_FITSCORE_DIFF_BEFORE_COMPARING_FITSCORE)
             {
                 if (firstModel.Fitting.FitScorePrc > secondModel.Fitting.FitScorePrc)
                     return true;


### PR DESCRIPTION
This pull request refactors two aspects of the FitScore calculation code.

- For PIDIdentifier, the constants deciding whether FitScore or R-Squared-Diff should be used to compare models are placed at the top as private members to more clearly indicate they are defined constants and to make it easier to adjust them.
- For the FitScore calculation, the process to find whether a data point should be stepped over due to it being in the indices to ignore is optimized by not looping over the entire indices to ignore list for every data point but instead sorting the list once and subsequently utilizing the fact that it is sorted.
- The existing tests cover the functionality of both changes, and should run successfully.