### PR TITLE
Add IndicesToIgnoreHandling to mean calculation

### DIFF
--- a/Dynamic/Identification/FitScoreCalculator.cs
+++ b/Dynamic/Identification/FitScoreCalculator.cs
@@ -227,7 +227,7 @@ namespace TimeSeriesAnalysis
             if (signal.Length == 0) return double.NaN;
 
             var vec = new Vec();
-            var avg = vec.Mean(signal);
+            var avg = vec.Mean(signal, indToIgnore: indToIgnore);
 
             if (!avg.HasValue)
                 return double.NaN;

--- a/Dynamic/Identification/FittingInfo.cs
+++ b/Dynamic/Identification/FittingInfo.cs
@@ -157,7 +157,7 @@ namespace TimeSeriesAnalysis.Dynamic
 
             // objective function " average of absolute model deviation
             //avgErrorObj = vec.SumOfSquareErr(ymeas_vals, ysim_vals);
-            var avgErrorObj = vec.Mean(vec.Abs(vec.Subtract(ymeas_vals, ysim_vals)));
+            var avgErrorObj = vec.Mean(vec.Abs(vec.Subtract(ymeas_vals, ysim_vals)), yIndicesToIgnore);
             if (avgErrorObj.HasValue)
             {
                 this.ObjFunValAbs = SignificantDigits.Format(avgErrorObj.Value, nDigits); ;

--- a/Dynamic/Identification/GainSchedIdentifier.cs
+++ b/Dynamic/Identification/GainSchedIdentifier.cs
@@ -518,7 +518,7 @@ namespace TimeSeriesAnalysis.Dynamic
             {
                 var simY_nobias = y_sim;
                 var estBias = vec.Mean(vec.Subtract(vec.GetValues(dataSet.Y_meas, dataSet.IndicesToIgnore),
-                    vec.GetValues(simY_nobias, dataSet.IndicesToIgnore)));
+                    vec.GetValues(simY_nobias, dataSet.IndicesToIgnore)), dataSet.IndicesToIgnore);
 
                 if (estBias.HasValue)
                 {

--- a/Dynamic/Identification/PidIdentifier.cs
+++ b/Dynamic/Identification/PidIdentifier.cs
@@ -18,7 +18,7 @@ namespace TimeSeriesAnalysis.Dynamic
     {
         private const double CUTOFF_FOR_GUESSING_PID_IN_MANUAL_FRAC = 0.005;
         const double rSquaredCutoffForInTrackingWarning = 0.02;//must be between 0 and 1
-        private const double MAX_RSQUARED_DIFF_BEFORE_COMPARING_FITSCORE = 95; // Must be below 100
+        private const double MAX_RSQUARED_DIFF_BEFORE_COMPARING_FITSCORE = 99.75; // Must be below 100
         private const double MIN_FITSCORE_DIFF_BEFORE_COMPARING_FITSCORE = 10; // Must be positive
         private const int MAX_ESTIMATIONS_PER_DATASET = 1;
         private const double MIN_DATASUBSET_URANGE_PRC = 0;
@@ -53,8 +53,9 @@ namespace TimeSeriesAnalysis.Dynamic
         {
             // If both models show a very high R-Squared-diff, look at fitscore instead if there is a significant difference
             if (firstModel.Fitting.RsqDiff > MAX_RSQUARED_DIFF_BEFORE_COMPARING_FITSCORE
-                && secondModel.Fitting.RsqDiff > MAX_RSQUARED_DIFF_BEFORE_COMPARING_FITSCORE
-                && Math.Abs(firstModel.Fitting.FitScorePrc - secondModel.Fitting.FitScorePrc) > MIN_FITSCORE_DIFF_BEFORE_COMPARING_FITSCORE)
+                && secondModel.Fitting.RsqDiff > MAX_RSQUARED_DIFF_BEFORE_COMPARING_FITSCORE)
+            //     && (Math.Abs(firstModel.Fitting.FitScorePrc - secondModel.Fitting.FitScorePrc) > Math.Abs(firstModel.Fitting.RsqDiff - secondModel.Fitting.RsqDiff)))
+            //     && Math.Abs(firstModel.Fitting.FitScorePrc - secondModel.Fitting.FitScorePrc) > MIN_FITSCORE_DIFF_BEFORE_COMPARING_FITSCORE)
             {
                 if (firstModel.Fitting.FitScorePrc > secondModel.Fitting.FitScorePrc)
                     return true;
@@ -654,10 +655,10 @@ namespace TimeSeriesAnalysis.Dynamic
       
             pidParam.Fitting.RsqDiff = regressResults.Rsq;
             pidParam.Fitting.ObjFunValDiff = regressResults.ObjectiveFunctionValue;
-            pidParam.Fitting.FitScorePrc = SignificantDigits.Format(FitScoreCalculator.Calc(dataSet.U.GetColumn(0), U_sim.GetColumn(0), indicesToIgnoreForEvalSim), nDigits);
+            pidParam.Fitting.FitScorePrc = SignificantDigits.Format(FitScoreCalculator.Calc(dataSet.U.GetColumn(0), dataSet.U_sim.GetColumn(0), indicesToIgnoreForEvalSim), nDigits);
             
-            pidParam.Fitting.ObjFunValAbs  = vec.SumOfSquareErr(dataSet.U.GetColumn(0), U_sim.GetColumn(0), 0);
-            pidParam.Fitting.RsqAbs = vec.RSquared(dataSet.U.GetColumn(0), U_sim.GetColumn(0), indicesToIgnoreForEvalSim, 0) * 100;
+            pidParam.Fitting.ObjFunValAbs  = vec.SumOfSquareErr(dataSet.U.GetColumn(0), dataSet.U_sim.GetColumn(0), 0);
+            pidParam.Fitting.RsqAbs = vec.RSquared(dataSet.U.GetColumn(0), dataSet.U_sim.GetColumn(0), indicesToIgnoreForEvalSim, 0) * 100;
 
             pidParam.Fitting.RsqAbs = SignificantDigits.Format(pidParam.Fitting.RsqAbs, nDigits);
             pidParam.Fitting.RsqDiff = SignificantDigits.Format(pidParam.Fitting.RsqDiff, nDigits);
@@ -666,7 +667,7 @@ namespace TimeSeriesAnalysis.Dynamic
 
             pidParam.DelayOutputOneSample = isPIDoutputDelayOneSample;
             // fitting abs?
-            return (pidParam, U_sim, indicesToIgnoreForEvalSim);
+            return (pidParam, dataSet.U_sim, indicesToIgnoreForEvalSim);
         }
 
 

--- a/Dynamic/Identification/UnitIdentifier.cs
+++ b/Dynamic/Identification/UnitIdentifier.cs
@@ -1168,7 +1168,7 @@ namespace TimeSeriesAnalysis.Dynamic
                 }
             }
             double[] diff = (new Vec(nanValue)).Subtract(yMeas_exceptIgnoredValues, ySim_exceptIgnoredValues);
-            double? bias = (new Vec(nanValue)).Mean(diff);
+            double? bias = (new Vec(nanValue)).Mean(diff, dataSet.IndicesToIgnore);
             double[] y_sim_ret = null;
             if (bias.HasValue && y_sim != null)
             {

--- a/Dynamic/UnitSimulator/UnitDataSet.cs
+++ b/Dynamic/UnitSimulator/UnitDataSet.cs
@@ -1,4 +1,4 @@
-using Accord.IO;
+﻿using Accord.IO;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
@@ -395,7 +395,7 @@ namespace TimeSeriesAnalysis.Dynamic
 
             for (int i = 0; i < U.GetNColumns(); i++)
             {
-                double? avg = (new Vec(BadDataID)).Mean(U.GetColumn(i));
+                double? avg = (new Vec(BadDataID)).Mean(U.GetColumn(i), IndicesToIgnore);
                 if (!avg.HasValue)
                     return null;
                 averages.Add(avg.Value);

--- a/TimeSeriesAnalysis/Vec.cs
+++ b/TimeSeriesAnalysis/Vec.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -990,7 +990,7 @@ namespace TimeSeriesAnalysis
                     }
                     var X_T_reg = Array2D<double>.Combine(X_T, Array2D<double>.CreateJaggedFromList(regX));
                     var Y_reg = Vec<double>.Concat(Y, Vec<double>.Fill(0, regX.Count()));
-                    double? Y_mean = vec.Mean(Y);
+                    double? Y_mean = vec.Mean(Y, indToIgnore: yIndToIgnore?.ToList());
                     double regressionWeight = (double)Y.Length / 1000;
                     var weights_reg = Vec<double>.Concat(weights, Vec<double>.Fill(regressionWeight, regX.Count())) ;
 


### PR DESCRIPTION
During FitScore calculation, the average signal value took the average of all values, which is then used ti see how much better a fitted model performs than a straight line through the signal. Now this average value is disregarding the values corresponding to the indicesToIgnore, so the scoring is only made on data that has also been used for model fitting.

The instances where the Vec.Mean() function was used have been updated to include the indicesToIgnore as an argument.

The scoring becomes slightly altered, so the PidIdentifier modelcomparison threshold for when to use FitScore and when to use RSquaredDiff is also changed.