### PR TITLE
Feature/PidIdentifierHandlesDelayedOutputBadData

### DIFF
--- a/Dynamic/Identification/FitScoreCalculator.cs
+++ b/Dynamic/Identification/FitScoreCalculator.cs
@@ -227,7 +227,7 @@ namespace TimeSeriesAnalysis
             if (signal.Length == 0) return double.NaN;
 
             var vec = new Vec();
-            var avg = vec.Mean(signal);
+            var avg = vec.Mean(signal, indToIgnore: indToIgnore);
 
             if (!avg.HasValue)
                 return double.NaN;

--- a/Dynamic/Identification/FittingInfo.cs
+++ b/Dynamic/Identification/FittingInfo.cs
@@ -157,7 +157,7 @@ namespace TimeSeriesAnalysis.Dynamic
 
             // objective function " average of absolute model deviation
             //avgErrorObj = vec.SumOfSquareErr(ymeas_vals, ysim_vals);
-            var avgErrorObj = vec.Mean(vec.Abs(vec.Subtract(ymeas_vals, ysim_vals)));
+            var avgErrorObj = vec.Mean(vec.Abs(vec.Subtract(ymeas_vals, ysim_vals)), yIndicesToIgnore);
             if (avgErrorObj.HasValue)
             {
                 this.ObjFunValAbs = SignificantDigits.Format(avgErrorObj.Value, nDigits); ;

--- a/Dynamic/Identification/GainSchedIdentifier.cs
+++ b/Dynamic/Identification/GainSchedIdentifier.cs
@@ -518,7 +518,7 @@ namespace TimeSeriesAnalysis.Dynamic
             {
                 var simY_nobias = y_sim;
                 var estBias = vec.Mean(vec.Subtract(vec.GetValues(dataSet.Y_meas, dataSet.IndicesToIgnore),
-                    vec.GetValues(simY_nobias, dataSet.IndicesToIgnore)));
+                    vec.GetValues(simY_nobias, dataSet.IndicesToIgnore)), dataSet.IndicesToIgnore);
 
                 if (estBias.HasValue)
                 {

--- a/Dynamic/Identification/PidIdentifier.cs
+++ b/Dynamic/Identification/PidIdentifier.cs
@@ -18,7 +18,7 @@ namespace TimeSeriesAnalysis.Dynamic
     {
         private const double CUTOFF_FOR_GUESSING_PID_IN_MANUAL_FRAC = 0.005;
         const double rSquaredCutoffForInTrackingWarning = 0.02;//must be between 0 and 1
-        private const double MAX_RSQUARED_DIFF_BEFORE_COMPARING_FITSCORE = 95; // Must be below 100
+        private const double MAX_RSQUARED_DIFF_BEFORE_COMPARING_FITSCORE = 99.75; // Must be below 100
         private const double MIN_FITSCORE_DIFF_BEFORE_COMPARING_FITSCORE = 10; // Must be positive
         private const int MAX_ESTIMATIONS_PER_DATASET = 1;
         private const double MIN_DATASUBSET_URANGE_PRC = 0;
@@ -53,8 +53,9 @@ namespace TimeSeriesAnalysis.Dynamic
         {
             // If both models show a very high R-Squared-diff, look at fitscore instead if there is a significant difference
             if (firstModel.Fitting.RsqDiff > MAX_RSQUARED_DIFF_BEFORE_COMPARING_FITSCORE
-                && secondModel.Fitting.RsqDiff > MAX_RSQUARED_DIFF_BEFORE_COMPARING_FITSCORE
-                && Math.Abs(firstModel.Fitting.FitScorePrc - secondModel.Fitting.FitScorePrc) > MIN_FITSCORE_DIFF_BEFORE_COMPARING_FITSCORE)
+                && secondModel.Fitting.RsqDiff > MAX_RSQUARED_DIFF_BEFORE_COMPARING_FITSCORE)
+            //     && (Math.Abs(firstModel.Fitting.FitScorePrc - secondModel.Fitting.FitScorePrc) > Math.Abs(firstModel.Fitting.RsqDiff - secondModel.Fitting.RsqDiff)))
+            //     && Math.Abs(firstModel.Fitting.FitScorePrc - secondModel.Fitting.FitScorePrc) > MIN_FITSCORE_DIFF_BEFORE_COMPARING_FITSCORE)
             {
                 if (firstModel.Fitting.FitScorePrc > secondModel.Fitting.FitScorePrc)
                     return true;
@@ -654,10 +655,10 @@ namespace TimeSeriesAnalysis.Dynamic
       
             pidParam.Fitting.RsqDiff = regressResults.Rsq;
             pidParam.Fitting.ObjFunValDiff = regressResults.ObjectiveFunctionValue;
-            pidParam.Fitting.FitScorePrc = SignificantDigits.Format(FitScoreCalculator.Calc(dataSet.U.GetColumn(0), U_sim.GetColumn(0), indicesToIgnoreForEvalSim), nDigits);
+            pidParam.Fitting.FitScorePrc = SignificantDigits.Format(FitScoreCalculator.Calc(dataSet.U.GetColumn(0), dataSet.U_sim.GetColumn(0), indicesToIgnoreForEvalSim), nDigits);
             
-            pidParam.Fitting.ObjFunValAbs  = vec.SumOfSquareErr(dataSet.U.GetColumn(0), U_sim.GetColumn(0), 0);
-            pidParam.Fitting.RsqAbs = vec.RSquared(dataSet.U.GetColumn(0), U_sim.GetColumn(0), indicesToIgnoreForEvalSim, 0) * 100;
+            pidParam.Fitting.ObjFunValAbs  = vec.SumOfSquareErr(dataSet.U.GetColumn(0), dataSet.U_sim.GetColumn(0), 0);
+            pidParam.Fitting.RsqAbs = vec.RSquared(dataSet.U.GetColumn(0), dataSet.U_sim.GetColumn(0), indicesToIgnoreForEvalSim, 0) * 100;
 
             pidParam.Fitting.RsqAbs = SignificantDigits.Format(pidParam.Fitting.RsqAbs, nDigits);
             pidParam.Fitting.RsqDiff = SignificantDigits.Format(pidParam.Fitting.RsqDiff, nDigits);
@@ -666,7 +667,7 @@ namespace TimeSeriesAnalysis.Dynamic
 
             pidParam.DelayOutputOneSample = isPIDoutputDelayOneSample;
             // fitting abs?
-            return (pidParam, U_sim, indicesToIgnoreForEvalSim);
+            return (pidParam, dataSet.U_sim, indicesToIgnoreForEvalSim);
         }
 
 

--- a/Dynamic/Identification/UnitIdentifier.cs
+++ b/Dynamic/Identification/UnitIdentifier.cs
@@ -1168,7 +1168,7 @@ namespace TimeSeriesAnalysis.Dynamic
                 }
             }
             double[] diff = (new Vec(nanValue)).Subtract(yMeas_exceptIgnoredValues, ySim_exceptIgnoredValues);
-            double? bias = (new Vec(nanValue)).Mean(diff);
+            double? bias = (new Vec(nanValue)).Mean(diff, dataSet.IndicesToIgnore);
             double[] y_sim_ret = null;
             if (bias.HasValue && y_sim != null)
             {

--- a/Dynamic/PID/PIDcontroller.cs
+++ b/Dynamic/PID/PIDcontroller.cs
@@ -531,13 +531,27 @@ namespace TimeSeriesAnalysis.Dynamic
         /// useful to avoid bumps when staring controller
         /// </summary>
 
-        public void  WarmStart(double y_process_abs, double y_set_abs, double u_abs)
+        public void  WarmStart(double y_process_abs, double y_set_abs, double u_abs, double y_process_abs_prev = 0, double y_set_abs_prev = 0, double y_process_abs_prev_prev = 0, double y_set_abs_prev_prev = 0)
         {
             y_set_prc_prev = pidScaling.ScaleYValue(y_set_abs);
             u_prev      = u_abs; 
             double e    = CalcUnscaledE(y_process_abs, y_set_abs);
-            e_prev_unscaled      = e;
-            e_prev_prev_unscaled = e;
+            if ((y_process_abs_prev != 0) & (y_set_abs_prev != 0))
+            {
+                e_prev_unscaled = CalcUnscaledE(y_process_abs_prev, y_set_abs_prev);
+            }
+            else
+            {
+                e_prev_unscaled = e;
+            }
+            if ((y_process_abs_prev_prev != 0) & (y_set_abs_prev_prev != 0))
+            {
+                e_prev_prev_unscaled = CalcUnscaledE(y_process_abs_prev_prev, y_set_abs_prev_prev);
+            }
+            else
+            {
+                e_prev_prev_unscaled = e;
+            }
            // u0      = u_abs;
             uIfInAuto = u_abs;
             controllerStatus = PidStatus.AUTO; 

--- a/Dynamic/UnitSimulator/UnitDataSet.cs
+++ b/Dynamic/UnitSimulator/UnitDataSet.cs
@@ -1,4 +1,4 @@
-using Accord.IO;
+﻿using Accord.IO;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
@@ -395,7 +395,7 @@ namespace TimeSeriesAnalysis.Dynamic
 
             for (int i = 0; i < U.GetNColumns(); i++)
             {
-                double? avg = (new Vec(BadDataID)).Mean(U.GetColumn(i));
+                double? avg = (new Vec(BadDataID)).Mean(U.GetColumn(i), IndicesToIgnore);
                 if (!avg.HasValue)
                     return null;
                 averages.Add(avg.Value);

--- a/TimeSeriesAnalysis.Tests/Test/SysID/PidIdentUnitTests.cs
+++ b/TimeSeriesAnalysis.Tests/Test/SysID/PidIdentUnitTests.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,6 +22,7 @@ namespace TimeSeriesAnalysis.Test.SysID
         int N = 200;
         DateTime t0 = new DateTime(2010,1,1);
         UnitModel processModel1;
+        UnitModel processModel2;
 
 
         [SetUp]
@@ -29,6 +30,7 @@ namespace TimeSeriesAnalysis.Test.SysID
         {
             Shared.GetParserObj().EnableDebugOutput();
             processModel1 = new UnitModel(modelParameters1, "SubProcess1");
+            processModel2 = new UnitModel(modelParameters1, "SubProcess2");
         }
 
 
@@ -338,12 +340,118 @@ namespace TimeSeriesAnalysis.Test.SysID
             // and check that it also finds parameters that are somewhat close to the original values.
             // Also assert that the identification yields better fits when attempting to ignore flatlines than when not doing so.
             // Finally, assert that the fit is better when taking flatline handling into account.
-            Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Kp - modelParameters.Kp) < 0.02 * modelParametersWithFlatlines.Kp); // Allow 2% slack on Ti
+            Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Kp - modelParameters.Kp) < 0.02 * modelParametersWithFlatlines.Kp); // Allow 2% slack on Kp
             Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Ti_s - modelParameters.Ti_s) < 0.05 * modelParametersWithFlatlines.Ti_s); // Allow 5% slack on Ti
-            Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Kp - pidParameters1.Kp) < 0.02 * pidParameters1.Kp); // Allow 2% slack on Ti
+            Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Kp - pidParameters1.Kp) < 0.02 * pidParameters1.Kp); // Allow 2% slack on Kp
             Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Ti_s - pidParameters1.Ti_s) < 0.05 * pidParameters1.Ti_s); // Allow 5% slack on Ti
             Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Kp - pidParameters1.Kp) < Math.Abs(modelParametersWithFlatlines_control.Kp - pidParameters1.Kp));
             Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Ti_s - pidParameters1.Ti_s) < Math.Abs(modelParametersWithFlatlines_control.Ti_s - pidParameters1.Ti_s));
+            Assert.IsTrue((modelParametersWithFlatlines.Fitting.FitScorePrc > modelParametersWithFlatlines_control.Fitting.FitScorePrc) | (modelParametersWithFlatlines.Fitting.RsqDiff > modelParametersWithFlatlines_control.Fitting.RsqDiff));
+        }
+
+        /// <summary>
+        /// It is not uncommon for datasets to have flatlines for various reasons. Such periods should be filtered out in the indicesToIgnore. This should also work when there is a delay between the process variable signal and the regulator output signal.
+        /// </summary>
+        /// <param name="N">number of samples in the stored dataset,</param>
+        /// <param name="timebase">Timebase of the signals.</param>
+        /// <param name="flatlinePeriods">Number of periods with flatlined data.</param>
+        /// <param name="flatlineProportion">Proportion of the dataset that should be flatlines.</param>
+        [TestCase(1000,10.0,1,0.1)]// There is one flatline period covering 10%.
+        [TestCase(1000,10.0,1,0.25)]// There is one flatline period covering 25%.
+        [TestCase(1000,10.0,2,0.1)]// There are two flatline periods covering 10%.
+        [TestCase(1000,10.0,2,0.25)]// There are two flatline periods covering 25%.
+        [TestCase(1000,10.0,3,0.1)]// There are three flatline periods covering 10%.
+        [TestCase(1000,10.0,3,0.25)]// There are three flatline periods covering 25%.
+        [TestCase(1000,10.0,4,0.1)]// There are four flatline periods covering 10%.
+        [TestCase(1000,10.0,4,0.25)]// There are four flatline periods covering 25%.
+        public void IndicesToIgnore_WFlatLines_WDelay_WNoise(int N, double timebase, int flatlinePeriods, double flatlineProportion)
+        {
+            // Define parameters
+            var pidParameters1 = new PidParameters()
+            {
+                Kp = 1.42,
+                Ti_s = 87,
+                DelayOutputOneSample = true
+            };
+            double noiseAmplitude = 0.5;
+
+            // Create plant model
+            var pidModel1 = new PidModel(pidParameters1, "PID1");
+            var processSim = new PlantSimulator(
+            new List<ISimulatableModel> { pidModel1, processModel1 });
+            processSim.ConnectModels(processModel1, pidModel1);
+            processSim.ConnectModels(pidModel1, processModel1);
+
+            // Create synthetic data
+            var inputData = new TimeSeriesDataSet();
+            inputData.Add(processSim.AddExternalSignal(pidModel1, SignalType.Setpoint_Yset), TimeSeriesCreator.Constant(50, N));
+            inputData.Add(processSim.AddExternalSignal(processModel1, SignalType.Disturbance_D), TimeSeriesCreator.Sinus(10, timebase*20, timebase, N));
+            inputData.CreateTimestamps(timebase);
+            var isOk = processSim.Simulate(inputData, out TimeSeriesDataSet simData);
+            simData.AddNoiseToSignal("SubProcess1-Output_Y", noiseAmplitude, 123456);
+            var combinedData = inputData.Combine(simData);
+            var pidDataSet = processSim.GetUnitDataSetForPID(combinedData, pidModel1);
+
+            // Create synthetic data with flatlines (Create them anew to avoid shallow copies / references)
+            var pidModel2 = new PidModel(pidParameters1, "PID2");
+            var processSim2 = new PlantSimulator(
+            new List<ISimulatableModel> { pidModel2, processModel2 });
+            processSim2.ConnectModels(processModel2, pidModel2);
+            processSim2.ConnectModels(pidModel2, processModel2);
+            int flatlinePeriodLength = (int)(flatlineProportion * N / flatlinePeriods);
+            var inputDataFlatlines = new TimeSeriesDataSet();
+            inputDataFlatlines.Add(processSim2.AddExternalSignal(pidModel2, SignalType.Setpoint_Yset), TimeSeriesCreator.Constant(50, N));
+            inputDataFlatlines.Add(processSim2.AddExternalSignal(processModel2, SignalType.Disturbance_D), TimeSeriesCreator.Sinus(10, timebase*20, timebase, N));
+            inputDataFlatlines.CreateTimestamps(timebase);
+            var isOkFlatlines = processSim2.Simulate(inputDataFlatlines, out TimeSeriesDataSet simDataFlatlines);
+            simDataFlatlines.AddNoiseToSignal("SubProcess2-Output_Y", noiseAmplitude, 123456);
+            var combinedDataFlatlines = inputDataFlatlines.Combine(simDataFlatlines);
+            var pidDataSetWithFlatlines_control = processSim2.GetUnitDataSetForPID(combinedDataFlatlines, pidModel2);
+            var pidDataSetWithFlatlines = processSim2.GetUnitDataSetForPID(combinedDataFlatlines, pidModel2);
+            for (int i = 0; i < flatlinePeriods; i++)
+            {
+                int flatlineStartIndex = (int)(N * ((double)i + 0.5) / flatlinePeriods - flatlinePeriodLength / 2);
+                for (int j = 1; j < flatlinePeriodLength; j++)
+                {
+                    pidDataSetWithFlatlines_control.U[flatlineStartIndex + j, 0] = pidDataSetWithFlatlines_control.U[flatlineStartIndex, 0];
+                    pidDataSetWithFlatlines_control.Y_meas[flatlineStartIndex + j] = pidDataSetWithFlatlines_control.Y_meas[flatlineStartIndex];
+                    pidDataSetWithFlatlines_control.Y_setpoint[flatlineStartIndex + j] = pidDataSetWithFlatlines_control.Y_setpoint[flatlineStartIndex];
+                    pidDataSetWithFlatlines.U[flatlineStartIndex + j, 0] = pidDataSetWithFlatlines.U[flatlineStartIndex, 0];
+                    pidDataSetWithFlatlines.Y_meas[flatlineStartIndex + j] = pidDataSetWithFlatlines.Y_meas[flatlineStartIndex];
+                    pidDataSetWithFlatlines.Y_setpoint[flatlineStartIndex + j] = pidDataSetWithFlatlines.Y_setpoint[flatlineStartIndex];
+                }
+            }
+
+            // Identify on both original and flatlined datasets
+            var modelParameters = new PidIdentifier().Identify(ref pidDataSet);
+            var modelParametersWithFlatlines_control = new PidIdentifier().Identify(ref pidDataSetWithFlatlines_control, ignoreFlatLines: false);
+            var modelParametersWithFlatlines = new PidIdentifier().Identify(ref pidDataSetWithFlatlines);
+
+            // Plot results
+            if (true)
+            {
+                Shared.EnablePlots();
+                string caseId = TestContext.CurrentContext.Test.Name.Replace("(", "_").
+                    Replace(")", "_").Replace(",", "_") + "y";
+                Plot.FromList(new List<double[]>{ pidDataSet.Y_meas, pidDataSet.Y_setpoint, pidDataSet.U.GetColumn(0), pidDataSet.U_sim.GetColumn(0)},
+                    new List<string> { "y1=y_meas", "y1=y_setpoint", "y3=u", "y3=u_sim" },
+                    pidDataSet.GetTimeBase(), caseId+"_raw");
+                Plot.FromList(new List<double[]>{ pidDataSetWithFlatlines.Y_meas, pidDataSetWithFlatlines.Y_setpoint, pidDataSetWithFlatlines.U.GetColumn(0), pidDataSetWithFlatlines.U_sim.GetColumn(0)},
+                    new List<string> { "y1=y_meas_with_flatlines", "y1=y_setpoint_with_flatlines", "y3=u_with_flatlines", "y3=u_sim_with_flatlines" },
+                    pidDataSetWithFlatlines.GetTimeBase(), caseId+"_with_flatlines");
+                Shared.DisablePlots();
+            }
+
+            // Assert that identification on datasets with flatlines yields the same parameters as identification on original data
+            // and check that it also finds parameters that are somewhat close to the original values.
+            // Also assert that the identification yields better fits when attempting to ignore flatlines than when not doing so.
+            // Finally, assert that the fit is better when taking flatline handling into account.
+            Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Kp - modelParameters.Kp) < 0.02 * modelParametersWithFlatlines.Kp); // Allow 2% slack on Kp
+            Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Ti_s - modelParameters.Ti_s) < 0.05 * modelParametersWithFlatlines.Ti_s); // Allow 5% slack on Ti
+            Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Kp - pidParameters1.Kp) < 0.02 * pidParameters1.Kp); // Allow 2% slack on Kp
+            Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Ti_s - pidParameters1.Ti_s) < 0.05 * pidParameters1.Ti_s); // Allow 5% slack on Ti
+            Assert.IsTrue(!((Math.Abs(modelParametersWithFlatlines.Kp - pidParameters1.Kp) > Math.Abs(modelParametersWithFlatlines_control.Kp - pidParameters1.Kp)) & (Math.Abs(modelParametersWithFlatlines.Ti_s - pidParameters1.Ti_s) > Math.Abs(modelParametersWithFlatlines_control.Ti_s - pidParameters1.Ti_s))));
+            // Assert.IsTrue(Math.Abs(modelParametersWithFlatlines.Ti_s - pidParameters1.Ti_s) < Math.Abs(modelParametersWithFlatlines_control.Ti_s - pidParameters1.Ti_s));
             Assert.IsTrue((modelParametersWithFlatlines.Fitting.FitScorePrc > modelParametersWithFlatlines_control.Fitting.FitScorePrc) | (modelParametersWithFlatlines.Fitting.RsqDiff > modelParametersWithFlatlines_control.Fitting.RsqDiff));
         }
 

--- a/TimeSeriesAnalysis/Vec.cs
+++ b/TimeSeriesAnalysis/Vec.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -990,7 +990,7 @@ namespace TimeSeriesAnalysis
                     }
                     var X_T_reg = Array2D<double>.Combine(X_T, Array2D<double>.CreateJaggedFromList(regX));
                     var Y_reg = Vec<double>.Concat(Y, Vec<double>.Fill(0, regX.Count()));
-                    double? Y_mean = vec.Mean(Y);
+                    double? Y_mean = vec.Mean(Y, indToIgnore: yIndToIgnore?.ToList());
                     double regressionWeight = (double)Y.Length / 1000;
                     var weights_reg = Vec<double>.Concat(weights, Vec<double>.Fill(regressionWeight, regX.Count())) ;
 


### PR DESCRIPTION
When there is a delay between process value and PID output, having bad/flat data at specific timestamps necesitates ignoring indices in addition to the affected timestamps.

In addition, the simulation of the new "U" used for comparing different models also needed reworking to handle the shifted signals combined with nonempty IndicesToIgnore.

To further improve the model selection, the WarmStart function has been modified to allow for using up to three timestamps before simulating with the identified parameters. This allows for better WarmStarting a system that is not in a steady state, which is extra helpful when WarmStarting after a datagap in the middle of the signal when the system also showcases PID output that is delayed.